### PR TITLE
Fix fullscreen bug on Linux - Fixes #48

### DIFF
--- a/objects/oIntroController.object.gmx
+++ b/objects/oIntroController.object.gmx
@@ -27,6 +27,10 @@
             <kind>1</kind>
             <string>alarm[0] = 180;
 txt = get_text("Title", "ControllerRecommended");
+if (os_type == os_linux && global.opfullscreen) {
+    window_set_fullscreen(false);
+    window_set_fullscreen(true);
+}
 </string>
           </argument>
         </arguments>


### PR DESCRIPTION
I forced a toggle of fullscreen in oIntroController Creation event, which gets rid of the garbled mess you have otherwise.
This seems to be the earliest place where I could force the toggle, if I tried it earlier, it would not let me do it. Considering that it's basically at the start of the game anyway, it doesn't really hurt much.